### PR TITLE
bug fix: running mnist-tensorflow and mnist-pytorch

### DIFF
--- a/mnist-tensorflow/workflow-continue.yaml
+++ b/mnist-tensorflow/workflow-continue.yaml
@@ -20,7 +20,7 @@ spec:
       apiVersion: batch.tensorstack.dev/v1beta1
       kind: TensorFlowTrainingJob
       metadata:
-        generateName: model-retrain-
+        generateName: model-train-
       spec:
         runPolicy:
           cleanUpPolicy: None

--- a/mnist-tensorflow/workflow-train.yaml
+++ b/mnist-tensorflow/workflow-train.yaml
@@ -69,7 +69,7 @@ spec:
   params:
     - name: command
       value: "python asset-hub-example/mnist-tensorflow/train.py --no_cuda --log_dir ./log --dataset_dir dataset --save_path saved_model/model_state_dict.pt"
-    - name: working_dirs
+    - name: working_dir
       value: /t9k/mnt
     - name: image
       value: registry.tensorstack.cn/t9kmirror/tensorflow:2.11.0


### PR DESCRIPTION
使用 branch skj-1205 运行了六个例子（tensorflow/pytorch 两种框架，分别运行模型训练、继续训练、模型评估三种功能），运行结果在 https://proxy.nc201.kube.tensorstack.net/t9k/asset-hub/web/#/models/3623abde-b06d-4c44-9e3c-024f3a675268/280551d6-bca5-447a-b753-6e5e5ca56655/?tab=training

其中 retrain 对应模型训练，train 对应继续训练，evaluate 对应模型评估。

branch skj-1205 中还做了另外两个修改，但不需要合并到 master：

1. 使用 tsz.io 代替 registry.tensorstack.cn，因为后者拉取镜像太慢。
2. tensorflow-evaluate 的 backoffLimit: 0 改为 backoffLimit: 1，这是 trainingjob 的 bug，已经告知 wangdi。